### PR TITLE
bugfix: svg line rendering

### DIFF
--- a/src/vkvg_context.c
+++ b/src/vkvg_context.c
@@ -1272,6 +1272,11 @@ void vkvg_render_svg (VkvgContext ctx, NSVGimage* svg, char *subId){
 			vkvg_move_to(ctx, p[0],p[1]);
 			for (int i = 1; i < path->npts-2; i += 3) {
 				p = &path->pts[i*2];
+				if ( i + 3 >= path -> npts -2 ) { //last one
+					if ( p [ 0 ] == p [ 4 ] && p [ 1 ] == p [ 5 ] ) {// same as first one
+						continue ;
+					}
+				}
 				vkvg_curve_to(ctx, p[0],p[1], p[2],p[3], p[4],p[5]);
 			}
 			if (path->closed)


### PR DESCRIPTION
Because the SVG line is converted to curves, removing last point will not work. So I add move last point code there and won't change other logic.

test data:
the svg file: https://n101n.xyz/n/do/anon.Download?k=pub%2Fkou.svg.kebk6mc9
Render result (before): https://n101n.xyz/n/do/anon.Download?k=pub%2Fbefore.png.kebk6md0
Render result (after): https://n101n.xyz/n/do/anon.Download?k=pub%2Fafter.png.kebk6mg9