### PR TITLE
Fix a possible memory leak in vkengine_create

### DIFF
--- a/tests/common/vkengine.c
+++ b/tests/common/vkengine.c
@@ -33,10 +33,6 @@ if (vkh_phyinfo_try_get_extension_properties(pi, #ext, NULL))	\
 	enabledExts[enabledExtsCount++] = #ext;						\
 }
 
-static void glfw_error_callback(int error, const char *description) {
-	fprintf(stderr, "vkengine: GLFW error %d: %s\n", error, description);
-}
-
 VkSampleCountFlagBits getMaxUsableSampleCount(VkSampleCountFlags counts)
 {
 	if (counts & VK_SAMPLE_COUNT_64_BIT) { return VK_SAMPLE_COUNT_64_BIT; }
@@ -111,10 +107,7 @@ bool instance_extension_supported (VkExtensionProperties* instanceExtProps, uint
 }
 
 vk_engine_t* vkengine_create (VkPhysicalDeviceType preferedGPU, VkPresentModeKHR presentMode, uint32_t width, uint32_t height) {
-	vk_engine_t* e = (vk_engine_t*)calloc(1,sizeof(vk_engine_t));
-
-	glfwSetErrorCallback(glfw_error_callback);
-	assert (glfwInit()==GLFW_TRUE);
+	glfwInit();
 	assert (glfwVulkanSupported()==GLFW_TRUE);
 
 	uint32_t enabledExtsCount = 0, phyCount = 0;
@@ -147,6 +140,7 @@ vk_engine_t* vkengine_create (VkPhysicalDeviceType preferedGPU, VkPresentModeKHR
 
 	free(instanceExtProps);
 
+	vk_engine_t* e = (vk_engine_t*)calloc(1,sizeof(vk_engine_t));
 	e->app = vkh_app_create(1 ,2 , "vkvgTest", enabledLayersCount, enabledLayers, enabledExtsCount, enabledExts);
 #if defined(DEBUG) && defined (VKVG_DBG_UTILS)
 	vkh_app_enable_debug_messenger(e->app
@@ -302,3 +296,4 @@ void vkengine_set_scroll_callback (VkEngine e, GLFWscrollfun onScroll){
 void vkengine_set_char_callback (VkEngine e, GLFWcharfun onChar){
 	glfwSetCharCallback(e->window, onChar);
 }
+

--- a/tests/common/vkengine.c
+++ b/tests/common/vkengine.c
@@ -33,6 +33,10 @@ if (vkh_phyinfo_try_get_extension_properties(pi, #ext, NULL))	\
 	enabledExts[enabledExtsCount++] = #ext;						\
 }
 
+static void glfw_error_callback(int error, const char *description) {
+	fprintf(stderr, "vkengine: GLFW error %d: %s\n", error, description);
+}
+
 VkSampleCountFlagBits getMaxUsableSampleCount(VkSampleCountFlags counts)
 {
 	if (counts & VK_SAMPLE_COUNT_64_BIT) { return VK_SAMPLE_COUNT_64_BIT; }
@@ -107,7 +111,8 @@ bool instance_extension_supported (VkExtensionProperties* instanceExtProps, uint
 }
 
 vk_engine_t* vkengine_create (VkPhysicalDeviceType preferedGPU, VkPresentModeKHR presentMode, uint32_t width, uint32_t height) {
-	glfwInit();
+	glfwSetErrorCallback(glfw_error_callback);
+	assert (glfwInit()==GLFW_TRUE);
 	assert (glfwVulkanSupported()==GLFW_TRUE);
 
 	uint32_t enabledExtsCount = 0, phyCount = 0;
@@ -296,4 +301,3 @@ void vkengine_set_scroll_callback (VkEngine e, GLFWscrollfun onScroll){
 void vkengine_set_char_callback (VkEngine e, GLFWcharfun onChar){
 	glfwSetCharCallback(e->window, onChar);
 }
-


### PR DESCRIPTION
The assertion checks could crash the program, leaving memory allocated by `e` un`free`d.
I got this memory leak in #61, with this fix `valgrind` goes from this:
![Screenshot_20220124_122845](https://user-images.githubusercontent.com/20150305/150776524-dab09a93-3c00-4108-a78f-39c3a7670b07.png)
to this:
![Screenshot_20220124_123529](https://user-images.githubusercontent.com/20150305/150776562-182d21f5-3f98-4599-ba05-e7dd1d97bc3a.png)
 