### PR TITLE
Remove constness from svgFragment

### DIFF
--- a/include/vkvg-svg.h
+++ b/include/vkvg-svg.h
@@ -54,7 +54,7 @@ VkvgSurface vkvg_surface_create_from_svg(VkvgDevice dev, uint32_t width, uint32_
  * @return The new vkvg surface with the parsed SVG fragment as content, or null if an error occured.
  */
 vkvg_public
-VkvgSurface vkvg_surface_create_from_svg_fragment(VkvgDevice dev, uint32_t width, uint32_t height, const char* svgFragment);
+VkvgSurface vkvg_surface_create_from_svg_fragment(VkvgDevice dev, uint32_t width, uint32_t height, char* svgFragment);
 
 vkvg_public
 void vkvg_svg_get_dimensions (VkvgSvg svg, uint32_t* width, uint32_t* height);
@@ -63,7 +63,7 @@ vkvg_public
 VkvgSvg vkvg_svg_load (const char* svgFilePath);
 
 vkvg_public
-VkvgSvg vkvg_svg_load_fragment (const char* svgFragment);
+VkvgSvg vkvg_svg_load_fragment (char* svgFragment);
 
 vkvg_public
 void vkvg_svg_render (VkvgSvg svg, VkvgContext ctx, const char* id);

--- a/src/nsvg/vkvg_nsvg.c
+++ b/src/nsvg/vkvg_nsvg.c
@@ -65,13 +65,13 @@ VkvgSurface _svg_load (VkvgDevice dev, NSVGimage* svg) {
 VkvgSurface vkvg_surface_create_from_svg (VkvgDevice dev, uint32_t width, uint32_t height, const char* filePath) {
 	return _svg_load(dev, nsvgParseFromFile(filePath, "px", (float)dev->hdpi));
 }
-VkvgSurface vkvg_surface_create_from_svg_fragment (VkvgDevice dev, uint32_t width, uint32_t height,const char* fragment) {
+VkvgSurface vkvg_surface_create_from_svg_fragment (VkvgDevice dev, uint32_t width, uint32_t height, char* svgFragment) {
 	return _svg_load(dev, nsvgParse(fragment, "px", (float)dev->hdpi));
 }
 VkvgSvg vkvg_svg_load (const char* svgFilePath) {
 	return nsvgParseFromFile(svgFilePath, "px", 96.0f);
 }
-VkvgSvg vkvg_svg_load_fragment (const char* svgFragment) {
+VkvgSvg vkvg_svg_load_fragment (char* svgFragment) {
 	return nsvgParse (svgFragment, "px", 96.0f);
 }
 void vkvg_svg_destroy (VkvgSvg svg) {

--- a/src/nsvg/vkvg_nsvg.c
+++ b/src/nsvg/vkvg_nsvg.c
@@ -66,7 +66,7 @@ VkvgSurface vkvg_surface_create_from_svg (VkvgDevice dev, uint32_t width, uint32
 	return _svg_load(dev, nsvgParseFromFile(filePath, "px", (float)dev->hdpi));
 }
 VkvgSurface vkvg_surface_create_from_svg_fragment (VkvgDevice dev, uint32_t width, uint32_t height, char* svgFragment) {
-	return _svg_load(dev, nsvgParse(fragment, "px", (float)dev->hdpi));
+	return _svg_load(dev, nsvgParse(svgFragment, "px", (float)dev->hdpi));
 }
 VkvgSvg vkvg_svg_load (const char* svgFilePath) {
 	return nsvgParseFromFile(svgFilePath, "px", 96.0f);


### PR DESCRIPTION
`nsvgParse`'s first argument `char* input` is non-`const`, actually it calls `nsvg__parseXM` which [modifies it](https://github.com/jpbruyere/vkvg/blob/f7deafc219026f1a3ec6cdc55f4298ebe4560dc9/src/nsvg/nanosvg.h#L349), so I removed the qualifier. With this, a compiler warning goes away.