### PR TITLE
Fix compatibility with CMake 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,10 +204,15 @@ IF(GLSLC AND XXD)
 
 	ADD_CUSTOM_TARGET(BuildShaders ALL DEPENDS ${SHADER_OUTPUTS})
 
-	ADD_CUSTOM_TARGET(ClearShadersHeader
-		COMMAND ${CMAKE_COMMAND} -E rm -f ${SHADERS_H}
-
-	)
+	if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
+		ADD_CUSTOM_TARGET(ClearShadersHeader
+			COMMAND ${CMAKE_COMMAND} -E rm -f ${SHADERS_H}
+		)
+	else()
+		ADD_CUSTOM_TARGET(ClearShadersHeader
+			COMMAND ${CMAKE_COMMAND} -E remove -f ${SHADERS_H}
+		)
+	endif()
 	ADD_CUSTOM_TARGET(BuildShadersHeader
 		DEPENDS ClearShadersHeader ${SHADER_OUTPUTS}
 	)


### PR DESCRIPTION
This PR fixes compatibility with CMake 3.16 (as shipped, e.g., by Ubuntu 20.04). vkvg currently specifies CMake 3.16 as the minimum CMake version.
According to https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-E-arg-rm, the command `rm` was only added in version 3.17 and superseded `remove`.
